### PR TITLE
match service codes by substring instead of exact equality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ocb-d2-scripts",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "main": "src/index.ts",
     "description": "DHIS2 Scripts for OCB",
     "scripts": {

--- a/src/data/OptionSetD2Repository.ts
+++ b/src/data/OptionSetD2Repository.ts
@@ -3,7 +3,7 @@ import { D2Api } from "types/d2-api";
 import { Async } from "domain/entities/Async";
 import { OptionSet } from "domain/entities/OptionSet";
 import { OptionSetRepository } from "domain/repositories/OptionSetRepository";
-import { promiseMap } from "./dhis2-utils";
+import { getInChunks, promiseMap } from "./dhis2-utils";
 import logger from "utils/log";
 
 export class OptionSetD2Repository implements OptionSetRepository {
@@ -22,6 +22,44 @@ export class OptionSetD2Repository implements OptionSetRepository {
         });
 
         return _(optionSets).flatten().value();
+    }
+
+    async save(optionSets: OptionSet[], options?: { dryRun: boolean }): Async<void> {
+        const allIds = optionSets.map(os => os.id);
+
+        const stats = await getInChunks(allIds, async optionSetIds => {
+            const response = await this.api.models.optionSets
+                .get({
+                    fields: { $owner: true },
+                    filter: { id: { in: optionSetIds } },
+                    paging: false,
+                })
+                .getData();
+
+            const optionSetsToSave = optionSetIds.map(optionSetId => {
+                const existingRecord = response.objects.find(d2Os => d2Os.id === optionSetId);
+                const optionSet = optionSets.find(os => os.id === optionSetId);
+                if (!optionSet) {
+                    throw Error("Cannot find optionSet");
+                }
+                return {
+                    ...(existingRecord || {}),
+                    name: optionSet.name,
+                    code: optionSet.code ?? "",
+                };
+            });
+
+            const postResponse = await this.api.metadata
+                .post(
+                    { optionSets: optionSetsToSave },
+                    { importMode: options?.dryRun ? "VALIDATE" : "COMMIT" }
+                )
+                .getData();
+
+            return [postResponse.stats];
+        });
+
+        console.debug("OptionSets saved:", JSON.stringify(stats, null, 2));
     }
 
     private getOptionsSets(page: number) {

--- a/src/data/OptionSetD2Repository.ts
+++ b/src/data/OptionSetD2Repository.ts
@@ -40,12 +40,12 @@ export class OptionSetD2Repository implements OptionSetRepository {
                 const existingRecord = response.objects.find(d2Os => d2Os.id === optionSetId);
                 const optionSet = optionSets.find(os => os.id === optionSetId);
                 if (!optionSet) {
-                    throw Error("Cannot find optionSet");
+                    throw Error(`OptionSet with id ${optionSetId} not found`);
                 }
                 return {
                     ...(existingRecord || {}),
                     name: optionSet.name,
-                    code: optionSet.code ?? "",
+                    code: optionSet.code,
                 };
             });
 

--- a/src/domain/entities/options/ServiceValidationStrategy.ts
+++ b/src/domain/entities/options/ServiceValidationStrategy.ts
@@ -193,6 +193,7 @@ export class ServiceValidationStrategy {
     }
 
     private validateStandardPattern(name: string): Maybe<StandardPattern> {
+        if (name.includes("OoP")) return undefined;
         // [Option Name] ([service acronym])
         const pattern = /^(?<optionName>.+?)\s*\(\s*(?<service>[^)]+)\s*\)$/;
         const match = name.match(pattern);

--- a/src/domain/entities/options/ServiceValidationStrategy.ts
+++ b/src/domain/entities/options/ServiceValidationStrategy.ts
@@ -107,7 +107,7 @@ export class ServiceValidationStrategy {
         switch (pattern.type) {
             case "standard_pattern": {
                 const { optionName, service } = pattern;
-                const serviceCode = settings.services.find(s => s.code === service)?.code;
+                const serviceCode = settings.services.find(s => service.includes(s.code))?.code;
                 if (!serviceCode)
                     return [
                         this.generateValidationError({
@@ -194,7 +194,7 @@ export class ServiceValidationStrategy {
 
     private validateStandardPattern(name: string): Maybe<StandardPattern> {
         // [Option Name] ([service acronym])
-        const pattern = /^(?<optionName>.+?)\s*\(\s*(?<service>[A-Z0-9_]+)\s*\)$/;
+        const pattern = /^(?<optionName>.+?)\s*\(\s*(?<service>[^)]+)\s*\)$/;
         const match = name.match(pattern);
         if (!match || !match.groups) return undefined;
 

--- a/src/domain/entities/options/ServiceValidationStrategy.ts
+++ b/src/domain/entities/options/ServiceValidationStrategy.ts
@@ -193,7 +193,6 @@ export class ServiceValidationStrategy {
     }
 
     private validateStandardPattern(name: string): Maybe<StandardPattern> {
-        if (name.includes("OoP")) return undefined;
         // [Option Name] ([service acronym])
         const pattern = /^(?<optionName>.+?)\s*\(\s*(?<service>[^)]+)\s*\)$/;
         const match = name.match(pattern);
@@ -202,6 +201,9 @@ export class ServiceValidationStrategy {
         const { optionName, service } = match.groups;
 
         if (!optionName || !service) return undefined;
+
+        if (service.includes("OoP")) return undefined;
+        if (service.startsWith("IN") || service.startsWith("OUT")) return undefined;
 
         return { optionName: optionName, service: service, type: "standard_pattern" };
     }

--- a/src/domain/repositories/OptionSetRepository.ts
+++ b/src/domain/repositories/OptionSetRepository.ts
@@ -3,4 +3,5 @@ import { OptionSet } from "domain/entities/OptionSet";
 
 export interface OptionSetRepository {
     getAll(): Async<OptionSet[]>;
+    save(optionSets: OptionSet[], options?: { dryRun: boolean }): Async<void>;
 }

--- a/src/domain/usecases/ValidateOptionSetsUseCase.ts
+++ b/src/domain/usecases/ValidateOptionSetsUseCase.ts
@@ -8,6 +8,7 @@ import { OptionSetValidator } from "domain/entities/OptionSetValidator";
 import { Exceptions, Project, Service } from "domain/entities/Service";
 import { promiseMap } from "data/dhis2-utils";
 import logger from "utils/log";
+import { Maybe } from "utils/ts-utils";
 
 export class ValidateOptionSetsUseCase {
     constructor(
@@ -60,6 +61,12 @@ export class ValidateOptionSetsUseCase {
         if (!options.update) return;
 
         const optionsToSave = this.fixAndGetOptions(optionSets, validationResults);
+        const optionSetsToSave = this.fixAndGetOptionSets(optionSets, validationResults);
+
+        console.log("Options to update:", optionSetsToSave.length);
+
+        await this.optionSetRepository.save(optionSetsToSave, { dryRun: !options.update });
+
         await promiseMap(optionsToSave, async option => {
             await this.optionRepository.save(option, { dryRun: !options.update });
         });
@@ -86,6 +93,35 @@ export class ValidateOptionSetsUseCase {
                     if (!option || !error.fixedValue) return undefined;
 
                     return { ...option, code: error.fixedValue };
+                })
+                .compact()
+                .value();
+        });
+    }
+
+    private fixAndGetOptionSets(
+        optionSets: OptionSet[],
+        validationResults: OptionSetValidator[]
+    ): OptionSet[] {
+        const optionSetsById = _(optionSets)
+            .keyBy(optionSet => optionSet.id)
+            .value();
+
+        return validationResults.flatMap((validationResult): OptionSet[] => {
+            const onlyFixableErrors = _(validationResult.errors)
+                .filter(error => error.type === "option_set")
+                .groupBy(error => error.id)
+                .filter(errors => errors.every(error => error.property === "code"))
+                .map(errors => errors.find(error => error.fixedValue))
+                .compact()
+                .value();
+
+            return _(onlyFixableErrors)
+                .map((error): Maybe<OptionSet> => {
+                    const option = optionSetsById[error.id];
+                    if (!option || !error.fixedValue) return undefined;
+
+                    return OptionSet.create({ ...option, code: error.fixedValue });
                 })
                 .compact()
                 .value();

--- a/src/domain/usecases/ValidateOptionSetsUseCase.ts
+++ b/src/domain/usecases/ValidateOptionSetsUseCase.ts
@@ -63,7 +63,7 @@ export class ValidateOptionSetsUseCase {
         const optionsToSave = this.fixAndGetOptions(optionSets, validationResults);
         const optionSetsToSave = this.fixAndGetOptionSets(optionSets, validationResults);
 
-        console.log("Options to update:", optionSetsToSave.length);
+        logger.debug(`Options to update: ${optionSetsToSave.length}`);
 
         await this.optionSetRepository.save(optionSetsToSave, { dryRun: !options.update });
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8698pp7e5

### :memo: Implementation

- Update validation for optionSets of type "SERVICE": match service codes using substring instead of exact equality
- Fixed bug that prevented optionSets from being updated

Example:

**Services**: ["ATFC", "MAT", "NEON"]

**Before:**

option name: **MUAC only (CRIT - ATFC) - ❌ not match because 'CRIT - ATFC' is not a valid service**

**Now:**

option name: **MUAC only (CRIT - ATFC) - ✅ Match because ATFC is a valid service**

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

#8698pp7e5